### PR TITLE
SCB-129 Do not defrag the backend database after compacted.

### DIFF
--- a/server/plugin/infra/registry/etcd/etcd.go
+++ b/server/plugin/infra/registry/etcd/etcd.go
@@ -76,22 +76,25 @@ func (c *EtcdClient) Compact(ctx context.Context, reserve int64) error {
 		return nil
 	}
 
+	t := time.Now()
 	_, err := c.Client.Compact(ctx, revToCompact, clientv3.WithCompactPhysical())
 	if err != nil {
 		util.Logger().Errorf(err, "Compact %s failed, revision is %d(current: %d, reserve %d)",
 			eps, revToCompact, curRev, reserve)
 		return err
 	}
-	util.Logger().Infof("Compacted %s, revision is %d(current: %d, reserve %d)", eps, revToCompact, curRev, reserve)
+	util.LogInfoOrWarnf(t, "Compacted %s, revision is %d(current: %d, reserve %d)", eps, revToCompact, curRev, reserve)
 
-	for _, ep := range eps {
+	// TODO can not defrag! because backend will always be unavailable when space in used is too large.
+	/*for _, ep := range eps {
+		t = time.Now()
 		_, err := c.Client.Defragment(ctx, ep)
 		if err != nil {
 			util.Logger().Errorf(err, "Defrag %s failed", ep)
 			continue
 		}
-		util.Logger().Infof("Defraged %s", ep)
-	}
+		util.LogInfoOrWarnf(t, "Defraged %s", ep)
+	}*/
 
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -120,7 +120,7 @@ func (s *ServiceCenterServer) autoCompactBackend() {
 		interval = 12 * time.Hour
 	}
 	util.Go(func(stopCh <-chan struct{}) {
-		util.Logger().Infof("start the automatic compact mechanism, compact once every %s, reserve %d",
+		util.Logger().Infof("enabled the automatic compact mechanism, compact once every %s, reserve %d",
 			core.ServerInfo.Config.CompactInterval, delta)
 		for {
 			select {

--- a/server/service/instances.go
+++ b/server/service/instances.go
@@ -574,10 +574,12 @@ func (s *InstanceService) Find(ctx context.Context, in *pb.FindInstancesRequest)
 	if apt.IsShared(provider) {
 		// it means the shared micro-services must be the same env with SC.
 		provider.Environment = apt.Service.Environment
+		findFlag += "(shared services in " + provider.Environment + " environment)"
 	} else {
 		// only allow shared micro-service instances found in different domains.
 		targetDomainProject = domainProject
 		provider.Tenant = domainProject
+		findFlag += "(" + provider.Environment + " services of the same domain)"
 	}
 
 	// 版本规则


### PR DESCRIPTION
Because the etcd will change to be unavailable when the defragment is in progress.